### PR TITLE
Remove checking environment to get 3DFSC HOME, Just use getHome

### DIFF
--- a/nysbc/__init__.py
+++ b/nysbc/__init__.py
@@ -59,8 +59,6 @@ class Plugin(pyworkflow.em.Plugin):
     @classmethod
     def getProgram(cls):
         """ Return the program binary that will be used. """
-        if NYSBC_3DFSC_HOME not in os.environ:
-            return None
         cmd = cls.getHome('ThreeDFSC', 'ThreeDFSC_Start.py')
         return str(cmd)
 


### PR DESCRIPTION
Hi! Buildbot was failing because it didn't have define the variable.  cls.getHome() should be taking care of the environment variable, so I removed it here.

With this, builbot fails now because there is no "activate" command. We need to install conda there.